### PR TITLE
stage vocabulary moves to bibdata ext shadow

### DIFF
--- a/grammars/relaton-ieee.rnc
+++ b/grammars/relaton-ieee.rnc
@@ -2,15 +2,17 @@ include "biblio-standoc.rnc" {
 
 DocumentType = "guide" | "recommended-practice" | "standard" | "whitepaper" | "redline" | "other"
 
-stage = element stage {
-  "draft" | "approved" | "superseded" | "withdrawn"
-}
-
 DocumentSubtype = "amendment" | "corrigendum" | "erratum" | "icap" | "document" | "industry-connections-report" | "industry-affiliate-network"
 
 }
 
 BibDataExtensionType &=
+        ## The stage of the document being authored, validated against the flavor's stage vocabulary.
+        ## This is a shadow of /bibdata/status/stage, which remains schema-generic:
+        ## the status of cited bibliographic items carries the vocabulary of the SDO
+        ## that published them, and is never constrained by the flavor
+        ## (metanorma-model-iso#156)
+        element stage { StageType }?,
         ## Document published for a limited period of time.  Can apply to any of the document types
         ## A Trial-Use standard is only described in the text of the introduction, it is not prominently displayed nor is it fielded data.
         ## https://standards.ieee.org/about/policies/opman/sect5/
@@ -26,6 +28,8 @@ BibDataExtensionType &=
         ## Program under which a white paper was authored
         program?
 
+
+StageType = "draft" | "approved" | "superseded" | "withdrawn"
 
 standard_status = element standard_status { "Inactive" | "Active" | "Superseded" }
 


### PR DESCRIPTION
Refs https://github.com/metanorma/metanorma-model-iso/issues/156

Same relocation as relaton-model-ogc (see the ticket): the `stage` enumeration override bound every cited bibitem's status, not only bibdata; the vocabulary moves to `bibdata/ext` as a shadow of `/bibdata/status/stage` (named `StageType`, values unchanged: draft/approved/superseded/withdrawn), joining the flavor's existing ext augmentation. A gated metanorma-ieee ticket covers the generator emitting the ext shadow.

🤖
